### PR TITLE
Update clone instructions to use HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A GRUB theme inspired by the Dark Souls series.
 - Clone or download the theme repository:
 
 ```bash
-git clone git@github.com:PedroMMarinho/grubsouls-theme.git
+git clone https://github.com/PedroMMarinho/grubsouls-theme.git
 ```
 
 ## Manually


### PR DESCRIPTION
Changed the git clone URL from SSH to HTTPS so it's easier for people without SSH keys to clone the repo. Tested and it worked for me! 👍